### PR TITLE
change letterbox_image method to resize_image method for fixing the detection bug

### DIFF
--- a/src/detector_AlexeyAB.cpp
+++ b/src/detector_AlexeyAB.cpp
@@ -62,7 +62,7 @@ float* detect(image im, float thresh, float hier_thresh, int* num_output_class)
 {
     float nms=.45;	// 0.4F
     int letterbox = 0;
-    image sized = letterbox_image(im, net.w, net.h); letterbox = 1;
+    image sized = resize_image(im, net.w, net.h);
     layer l = net.layers[net.n-1];
 
     float *X = sized.data;


### PR DESCRIPTION
change letterbox method to resize method

I found a bug that detection results are different form AlexeyAB's fork.

Because when you resize the image for changing the image size to yolo input size, you used letterbox_image method.

But AlexeyAB's used resize_image method.

After modifying that bug, I got a right result.

Thank you.